### PR TITLE
開発環境でのDockerの導入を廃止した

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,30 +5,20 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: mysql2
+  adapter: sqlite3
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: password
 
 development:
   <<: *default
-  database: docker_development
-  username: root
-  password: password
-  host: db
-  port: 3306
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: docker_test
-  username: root
-  password: password
-  host: db
-  port: 3306
+  database: db/test.sqlite3
 
 production:
   <<: *default


### PR DESCRIPTION
## 実装したこと
`database.yml`のコンテナでのdocker dbを変更した。

## 背景
開発環境にDockerを使用していたが、開発スピードの効率を考えて、Dockerの利用を停止した。